### PR TITLE
[BUGFIX] make regex typesafe

### DIFF
--- a/lib/Validators/RegExValidator.js
+++ b/lib/Validators/RegExValidator.js
@@ -6,7 +6,7 @@ var skmatc = require('../skmatc.js');
 module.exports = skmatc.create(function(schema) {
     return schema instanceof RegExp;
 }, function(schema, data, path) {
-    if(data === null || data === undefined) return this.fail('Expected ' + (path || 'value') + ' to be a defined non-null value but got ' + data + ' instead');
+    if(typeof data !== 'string') return this.fail('Expected ' + (path || 'value') + ' to be a defined string value but got ' + JSON.stringify(data) + ' instead');
     return this.assert(schema.test(data), 'Expected ' + (path || 'value') + ' to match the regular expression "' + schema.toString() + '" but got ' + JSON.stringify(data) + ' instead');
 }, {
     name: 'regexp validation'


### PR DESCRIPTION
If data is ``true``, it will match ``/^true$/``,  but should fail.